### PR TITLE
FEAT: Add Avatar Component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,37 +1,11 @@
-import { Alert } from "./components/alert/Alert";
+import { Avatar } from "./components/avatar/Avatar";
 import "./App.css";
 
-import { useState } from "react";
-
 const App = () => {
-  const [alertDisplay, setAlertDisplay] = useState("none");
-  const alertHandler = () => {
-    setAlertDisplay("flex");
-    setTimeout(() => {
-      setAlertDisplay("none");
-    }, 5000);
-  };
-
-  const closeHandler = () => {
-    setAlertDisplay("none");
-  };
-
   return (
     <div className="App">
-      <button className="button btn-solid-primary" onClick={alertHandler}>
-        Show Sample Solid Danger Alert
-      </button>
-      {alertDisplay !== "none" && (
-        <Alert
-          variant="wicon"
-          action="danger"
-          position="top-right"
-          theme="solid-danger"
-          closeHandler={closeHandler}
-        >
-          Login Failed
-        </Alert>
-      )}
+      <Avatar size="xl" />
+      <Avatar variant="img" size="xl" shape="circle" />
     </div>
   );
 };

--- a/src/components/avatar/Avatar.css
+++ b/src/components/avatar/Avatar.css
@@ -1,0 +1,59 @@
+/* BASIC */
+.avatar {
+  height: 50px;
+  width: 50px;
+}
+
+/* TEXT VARIANT */
+.av-text {
+  align-items: center;
+  display: flex;
+  font-size: var(--fs-xs-1);
+  font-weight: var(--fw-500);
+  justify-content: center;
+  padding: var(--space-xs);
+  text-transform: uppercase;
+}
+
+/* AVATAR SIZES */
+.av-xs {
+  height: 25px;
+  width: 25px;
+}
+
+.av-sm {
+  font-size: var(--fs-sm-1);
+  height: 40px;
+  width: 40px;
+}
+
+.av-md {
+  font-size: var(--fs-md-1);
+  height: 50px;
+  width: 50px;
+}
+
+.av-lg {
+  font-size: var(--fs-lg-1);
+  height: 70px;
+  width: 70px;
+}
+
+.av-xl {
+  font-size: var(--fs-xl-1);
+  height: 90px;
+  width: 90px;
+}
+
+/* AVATAR SHAPES */
+.av-square {
+  border-radius: 0;
+}
+
+.av-rounded {
+  border-radius: var(--br-xs);
+}
+
+.av-circle {
+  border-radius: var(--br-full);
+}

--- a/src/components/avatar/Avatar.jsx
+++ b/src/components/avatar/Avatar.jsx
@@ -1,0 +1,53 @@
+/**
+ * Welcome to @VISact/Avatar!
+ *
+ * The Avatar component is used for user profile images. It comes in two major
+ * variants of image and text.
+ *
+ * NOTE: All the props are optional
+ * @prop {string} variant - The variant of avatar to use. e.g. image, text
+ * @prop {string} source - The source of image to be used in avatar.
+ * @prop {string} text - For the text variant the text to be displayed in the avatar.
+ * @prop {string} shape - Shape of Avatar. e.g. Circle, square, rounded, etc.
+ * @prop {hex-code-string} background - For the text variant the background color to be used
+ * @prop {hex-code-string} color - For the text variant the font color to be used
+ * @prop {string} size - The size of the avatar component. e.g. xs, sm, md, lg, xl
+ *
+ * TODO: All animation to avatars on hover
+ *
+ * @see Docs - {coming soon...}
+ * @see Source - https://github.com/VishalPatil18/VISact/tree/development/src/components/avatar
+ */
+
+import "./Avatar.css";
+
+const Avatar = ({
+  variant = "text",
+  source = "https://picsum.photos/200",
+  text = "aa",
+  shape = "circle",
+  background = "#23a6f0",
+  color = "white",
+  size = "md",
+}) => {
+  return (
+    <>
+      {variant === "img" ? (
+        <img
+          className={`avatar av-${shape} av-${size}`}
+          src={source}
+          alt="avatar"
+        />
+      ) : (
+        <span
+          className={`avatar av-text av-${shape} av-${size}`}
+          style={{ backgroundColor: background, color: color }}
+        >
+          {text.substring(0, 2)}
+        </span>
+      )}
+    </>
+  );
+};
+
+export { Avatar };


### PR DESCRIPTION
### 📝 Description

Added the Avatar Component. It is used for profile images or user profile menus.

### 🚀 New behavior

1. Added the two variants
   - text
   - image
2. The component accepts props like
   - `variant` - The variant of the avatar to use. e.g. image, text
   - `source` - The source of the image to be used in avatar
   - `text` - For the text variant the text to be displayed in the avatar
   - `shape` - Shape of Avatar. e.g. Circle, square, rounded, etc
   - `background` - For the text variant the background color to be used
   - `color` - For the text variant the font color to be used
   - `size` - The size of the avatar component. e.g. xs, sm, md, lg, xl

> All props are optional

### 🖼 Screenshots

![Screenshot 2022-03-03 at 19 06 57](https://user-images.githubusercontent.com/62737267/156575889-d0c48a0d-9e3c-4436-9dc7-af0c8547fdb2.png)

### 💣 Is this a breaking change?
- [ ] Yes
- [x] No

### 🔬 Is the code self-reviewed?
- [x] Yes
- [ ] No

### 📋 Is the code well-formatted?
- [x] Yes
- [ ] No


### 🔗 Related to Issue #4 

> NOTE: The changes in `App.jsx` file are just for the development purpose of the current component.
