### PR TITLE
FEAT: Add Badge Component

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,7 @@
 .App {
   text-align: center;
   position: relative;
+  display: grid;
+  place-items: center;
+  height: 100vh;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,24 @@
+import { Badge } from "./components/badge/Badge";
 import { Avatar } from "./components/avatar/Avatar";
 import "./App.css";
 
 const App = () => {
   return (
     <div className="App">
-      <Avatar size="xl" />
-      <Avatar variant="img" size="xl" shape="circle" />
+      <button className="badge-container">
+        Button
+        <Badge variant="numeric" value="12+" />
+      </button>
+
+      <div className="badge-container">
+        <Avatar variant="img" />
+        <Badge variant="solid" themeColor="success" />
+      </div>
+
+      <div className="badge-container">
+        <Avatar variant="img" />
+        <Badge variant="outline" themeColor="danger" />
+      </div>
     </div>
   );
 };

--- a/src/components/badge/Badge.css
+++ b/src/components/badge/Badge.css
@@ -1,0 +1,97 @@
+/* BASIC */
+.badge-container {
+  position: relative;
+}
+
+.badge {
+  border-radius: var(--br-full);
+  position: absolute;
+  right: -15px;
+  top: -10px;
+}
+
+/* BADGE SMALL */
+.bdg-sm {
+  height: 12px;
+  width: 12px;
+}
+
+/* BADGE MEDIUM */
+.bdg-md {
+  height: 16px;
+  width: 16px;
+}
+
+/* BADGE LARGE */
+.bdg-lg {
+  height: 20px;
+  width: 20px;
+}
+
+/* BADGE COLORS */
+.bdg-primary {
+  background-color: var(--primary);
+}
+
+.bdg-success {
+  background-color: var(--success);
+}
+
+.bdg-danger {
+  background-color: var(--danger);
+}
+
+.bdg-warning {
+  background-color: var(--warning);
+  color: var(--dark);
+}
+
+.bdg-dark {
+  background-color: var(--dark);
+}
+
+/* NUMERIC BADGE */
+.bdg-numeric {
+  color: white;
+  font-size: var(--fs-xs-1);
+  font-weight: var(--fw-500);
+  height: fit-content;
+  padding: 3px 6px;
+  text-align: center;
+  width: fit-content;
+}
+
+/* SOLID BADGE */
+.bdg-solid {
+  border: 2px solid white;
+  bottom: 0px;
+  padding: 0px;
+  right: 0px;
+  top: initial;
+}
+
+/* OUTLINE BADGE */
+.bdg-outline {
+  background-color: initial;
+  border: 4px solid var(--primary);
+  height: calc(100% + 8px);
+  left: -4px;
+  top: -4px;
+  width: calc(100% + 8px);
+}
+
+.bdg-outline-danger {
+  border-color: var(--danger);
+}
+
+.bdg-outline-success {
+  border-color: var(--success);
+}
+
+.bdg-outline-warning {
+  border-color: var(--warning);
+}
+
+.bdg-outline-dark {
+  border-color: var(--dark);
+}

--- a/src/components/badge/Badge.jsx
+++ b/src/components/badge/Badge.jsx
@@ -1,0 +1,51 @@
+/**
+ * Welcome to @VISact/Badge!
+ *
+ * The Badge component is used for user specifiying users current activity or minimal
+ * information like no. of notifications or items in cart, etc.
+ *
+ * NOTE: All the props are optional
+ * @prop {string} variant - The variant of badge to use. e.g. numeric, solid, outline
+ * @prop {string} value - For the numberic variant the value to be displayed in the badge.
+ * @prop {string} themeColor - For the numeric and solid variant the background
+ *                                      color to be used and for the outline variant the
+ *                                      color of border. eg. warning, danger, dark, etc
+ * @prop {string} size - The size of the badge component. e.g. sm, md, lg
+ *
+ * TODO: Add animations to badges on hover
+ *
+ * @see Docs - {coming soon...}
+ * @see Source - https://github.com/VishalPatil18/VISact/tree/development/src/components/badge
+ */
+
+import "./Badge.css";
+
+const Badge = ({
+  variant = "solid",
+  value = "99",
+  themeColor = "primary",
+  size = "md",
+}) => {
+  return (
+    <>
+      {variant === "solid" ? (
+        /******* SOLID *******/
+        <span
+          className={`badge bdg-${size} bdg-${themeColor} bdg-solid`}
+        ></span>
+      ) : variant === "numeric" ? (
+        /******* NUMERIC *******/
+        <span className={`badge bdg-${size} bdg-${themeColor} bdg-numeric`}>
+          {value}
+        </span>
+      ) : (
+        /******* OUTLINE *******/
+        <span
+          className={`badge bdg-${size} bdg-outline bdg-outline-${themeColor}`}
+        ></span>
+      )}
+    </>
+  );
+};
+
+export { Badge };


### PR DESCRIPTION
### 📝 Description

Added the Badge Component. It is used for displaying users' current activity or notifications.

### 🚀 New behavior

1. Added the three variants
   - solid
   - numeric
   - outline
3. The component accepts props like
   - variant - The variant to be used among the 3 mentioned above
   - value - The value to be used for the numeric variant
   - themeColor - For the numeric and solid variant the background color to be used and for the outline variant the color of the border. eg. warning, danger, dark, etc
   - size - The size of the badge component. e.g. sm, md, lg

> All props are optional

### 🖼 Screenshots

![Screenshot 2022-03-04 at 10 44 51](https://user-images.githubusercontent.com/62737267/156703774-cf213586-54e5-4bac-9985-30bc8c1fb606.png)

### 💣 Is this a breaking change?
- [ ] Yes
- [x] No

### 🔬 Is the code self-reviewed?
- [x] Yes
- [ ] No

### 📋 Is the code well-formatted?
- [x] Yes
- [ ] No

### 🔗 Related to Issue #5 
